### PR TITLE
fix: onboard cli not setting setup to be true

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,13 @@ mv my_digital_being/config_sample my_digital_being/config
 
 ### 3. Onboarding & Configuration
 
-You can pick one of these approaches:
+You can pick one of these approaches after you've navigated to the project directory:
 
-- **CLI:** `python my_digital_being/tools/onboard.py`
-- **Web UI:** `python my_digital_being/server.py` then open `http://localhost:8000` in your browser and follow the onboarding prompts.
+```bash
+cd my_digital_being
+```
+- **CLI:** `python -m tools.onboard`
+- **Web UI:** `python -m server` then open `http://localhost:8000` in your browser and follow the onboarding prompts.
 
 Either way, you’ll be guided through:
 
@@ -183,7 +186,7 @@ Either way, you’ll be guided through:
 
 ### 4. Launch the Agent
 
-- **CLI:** `python -m my_digital_being/framework.main`
+- **CLI:** `python -m framework.main`
 - **Web UI:** Once onboarding is complete, a Start button appears—click to run the main loop.
 
 ---

--- a/my_digital_being/server.py
+++ b/my_digital_being/server.py
@@ -11,11 +11,10 @@ Implements:
 import asyncio
 import json
 import logging
-import os
 import http
 import mimetypes
 from pathlib import Path
-from typing import Dict, Any, Set, Optional, Union, Tuple
+from typing import Dict, Any, Set, Union, Tuple
 from datetime import datetime
 
 import websockets

--- a/my_digital_being/tools/onboard.py
+++ b/my_digital_being/tools/onboard.py
@@ -1,13 +1,11 @@
-import os
 import json
 import logging
-import sys
 import asyncio
 from pathlib import Path
 
 # We'll need to call api_manager in a synchronous context
 from framework.api_management import api_manager
-from framework.activity_loader import ActivityLoader  # [ADDED] for dynamically listing activities
+from framework.activity_loader import ActivityLoader
 
 # Adjust these if your config is stored differently:
 CHARACTER_CONFIG_FILE = Path(__file__).parent.parent / "config" / "character_config.json"
@@ -310,6 +308,9 @@ def main():
     if "activities_config" not in activity_constraints:
         activity_constraints["activities_config"] = {}
     configure_activities_cli(activity_constraints["activities_config"])
+
+    # Set setup_complete to true
+    character_config["setup_complete"] = True
 
     # Save updated (without storing any user-provided API keys in JSON)
     print("\nSaving updated JSON configs...")


### PR DESCRIPTION
If you setup your agent through the cli tool, the config never completes properly because the `setup_complete` flag is never set. This PR fixes that issue.

Additionally, I fixed the commands needed to run the onboarding tool and agent in the documentation.