### PR TITLE
docs: README, clarify branding for "digital beings" and fix refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ env/
 
 # Logs
 *.log
+
+# VSCode
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Pippin - Autonomous Being Framework
+# Pippin - The Digital Being Framework for Autonomous Agents
 
-Welcome to Pippin — a flexible, open-source Autonomous Being Framework to create a digital AI “being” that:
+Welcome to Pippin — a flexible, open-source framework to create a digital “being” that:
 
 - Learns about your goals/objectives and your character’s persona.
 - Connects to various tools or APIs (via API keys or OAuth flows through Composio) to perform tasks.
@@ -141,8 +141,8 @@ Fork this repo on GitHub.
 Clone your fork:
 
 ```bash
-git clone https://github.com/<your-username>/autonomous-being-framework.git
-cd autonomous-being-framework
+git clone https://github.com/<your-username>/pippin-draft.git
+cd pippin-draft
 ```
 
 ### 2. Install Dependencies
@@ -558,4 +558,4 @@ This project is licensed under the MIT License. See the LICENSE file.
 
 ---
 
-That’s it! We hope you enjoy building with the Autonomous Being Framework. Whether you want your AI to brainstorm content, spin up tokens on Solana, or implement an entirely new skill from scratch, we’ve got you covered. If you have any questions or suggestions, please reach out or open an issue—happy hacking!
+That’s it! We hope you enjoy building with the Pippin Framework. Whether you want your AI to brainstorm content, spin up tokens on Solana, or implement an entirely new skill from scratch, we’ve got you covered. If you have any questions or suggestions, please reach out or open an issue—happy hacking!


### PR DESCRIPTION
- previously auto-generated README.md contained incorrect git repo ref
- fixed cloning instructions/path
- avoid confusion of "autonomous being" and usage of "digital being"
- match README.md branding of "digital being" with (my_digital_being) code
- update .gitignore for VSCode workspaces