### PR TITLE
Add support for other open ai models. And fix a bug in combined_code.py

### DIFF
--- a/combined_code.py
+++ b/combined_code.py
@@ -12,7 +12,7 @@ TARGETS = [
     "my_digital_being/tools",
     "my_digital_being/activities",
     "my_digital_being/static",
-    "my_digital_being/config",
+    "my_digital_being/config_sample",
     "my_digital_being/server.py",
 ]
 

--- a/combined_code.txt
+++ b/combined_code.txt
@@ -1906,8 +1906,9 @@ class ChatSkill:
             return False
 
     async def get_chat_completion(self, prompt: str, 
-                                system_prompt: str = "You are a helpful AI assistant.", 
-                                max_tokens: int = 150) -> Dict[str, Any]:
+                                  system_prompt: str = "You are a helpful AI assistant.", 
+                                  max_tokens: int = 150,
+                                  model: str = "gpt-4o") -> Dict[str, Any]:
         """
         Get a chat completion response.
 
@@ -1915,6 +1916,7 @@ class ChatSkill:
             prompt: The user's input prompt
             system_prompt: Optional system message to set the AI's behavior
             max_tokens: Maximum tokens in the response
+            model: The model to use for the chat completion
 
         Returns:
             Dictionary containing success status, response data or error
@@ -1928,7 +1930,7 @@ class ChatSkill:
 
         try:
             response = self.client.chat.completions.create(
-                model="gpt-4o",  # the newest OpenAI model is "gpt-4o" which was released May 13, 2024
+                model=model,  # Use the model parameter
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": prompt}
@@ -2405,16 +2407,14 @@ class XAPISkill:
         self.posts_count = 0
 
 ##### my_digital_being/tools/onboard.py #####
-import os
 import json
 import logging
-import sys
 import asyncio
 from pathlib import Path
 
 # We'll need to call api_manager in a synchronous context
 from framework.api_management import api_manager
-from framework.activity_loader import ActivityLoader  # [ADDED] for dynamically listing activities
+from framework.activity_loader import ActivityLoader
 
 # Adjust these if your config is stored differently:
 CHARACTER_CONFIG_FILE = Path(__file__).parent.parent / "config" / "character_config.json"
@@ -2718,6 +2718,9 @@ def main():
         activity_constraints["activities_config"] = {}
     configure_activities_cli(activity_constraints["activities_config"])
 
+    # Set setup_complete to true
+    character_config["setup_complete"] = True
+
     # Save updated (without storing any user-provided API keys in JSON)
     print("\nSaving updated JSON configs...")
     save_json_config(character_config_path, character_config)
@@ -2837,7 +2840,7 @@ logger = logging.getLogger(__name__)
 @activity(
     name="analyze_new_commits",
     energy_cost=0.4,
-    cooldown=100,  # e.g. 100 seconds for testing; update as needed (e.g. 86400 for daily)
+    cooldown=1000,  # e.g. 100 seconds for testing; update as needed (e.g. 86400 for daily)
     required_skills=['github_repo_commits']
 )
 class AnalyzeNewCommitsActivity(ActivityBase):
@@ -2851,10 +2854,10 @@ class AnalyzeNewCommitsActivity(ActivityBase):
     def __init__(self):
         super().__init__()
         self.composio_action = "GITHUB_LIST_COMMITS"
-        self.github_owner = "yoheinakajima"
-        self.github_repo = "pippin-py"
+        self.github_owner = "yoheinakajima" #example githubt username
+        self.github_repo = "pippin" #example repo
         self.github_branch = "main"
-        self.lookback_hours = 144  # or 24, etc.
+        self.lookback_hours = 144  # hours to look back
 
     async def execute(self, shared_data) -> ActivityResult:
         try:
@@ -4347,11 +4350,10 @@ Implements:
 import asyncio
 import json
 import logging
-import os
 import http
 import mimetypes
 from pathlib import Path
-from typing import Dict, Any, Set, Optional, Union, Tuple
+from typing import Dict, Any, Set, Union, Tuple
 from datetime import datetime
 
 import websockets

--- a/my_digital_being/skills/skill_chat.py
+++ b/my_digital_being/skills/skill_chat.py
@@ -39,8 +39,9 @@ class ChatSkill:
             return False
 
     async def get_chat_completion(self, prompt: str, 
-                                system_prompt: str = "You are a helpful AI assistant.", 
-                                max_tokens: int = 150) -> Dict[str, Any]:
+                                  system_prompt: str = "You are a helpful AI assistant.", 
+                                  max_tokens: int = 150,
+                                  model: str = "gpt-4o") -> Dict[str, Any]:
         """
         Get a chat completion response.
 
@@ -48,6 +49,7 @@ class ChatSkill:
             prompt: The user's input prompt
             system_prompt: Optional system message to set the AI's behavior
             max_tokens: Maximum tokens in the response
+            model: The model to use for the chat completion
 
         Returns:
             Dictionary containing success status, response data or error
@@ -61,7 +63,7 @@ class ChatSkill:
 
         try:
             response = self.client.chat.completions.create(
-                model="gpt-4o",  # the newest OpenAI model is "gpt-4o" which was released May 13, 2024
+                model=model,  # Use the model parameter
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": prompt}


### PR DESCRIPTION
Change 1: Made the model a variable, which defaults to 4o in `skill_chat.py`

This way, developers can use models like 4o-mini, o1 and o1-mini without having change the model name hardcode. Perhaps mix different models for different stages of an agentic tasks.

Change 2: `my_digital_being/config` isn't a directory anymore, the new name is `my_digital_being/config_sample`, fixed that in `combined_code.py`