### PR TITLE
fix: add apiKeyInput to apiKeyModal

### DIFF
--- a/my_digital_being/static/index.html
+++ b/my_digital_being/static/index.html
@@ -688,6 +688,7 @@
       </div>
       <div class="modal-body">
         <p id="apiKeyModalMessage"></p>
+        <input type="text" id="apiKeyInput" class="api-key-input" placeholder="API Key" />
       </div>
       <div class="modal-footer">
         <button class="btn secondary" onclick="closeApiKeyModal()">Cancel</button>


### PR DESCRIPTION
## **Description**

The config button in the `API Key Management` tab is broken as the apiKeyInput field is not available inside of the api key modal.

Fixes # (issue)

## **Type of Change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## **How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] After clicking on the config button, the api key modal showed up. After entering the API key, the relevant field shows configured and the activity log indicates DrawActivity was successful

<img width="1376" alt="Screenshot 2025-01-21 at 6 29 47 PM" src="https://github.com/user-attachments/assets/fb2101f4-18cd-4944-9859-b3ef6c5d3d15" />

<img width="1380" alt="Screenshot 2025-01-21 at 6 28 09 PM" src="https://github.com/user-attachments/assets/751ffdd3-c846-4f52-b555-ab4541a3020a" />


## **Checklist:**

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## **Screenshots (if applicable):**

## **Additional Notes:**

Add any other information that is important to this pull request.
