### PR TITLE
finegrained activities config customization

### DIFF
--- a/my_digital_being/activities/activity_post_recent_memory_tweet.py
+++ b/my_digital_being/activities/activity_post_recent_memory_tweet.py
@@ -48,7 +48,8 @@ class PostRecentMemoriesTweetActivity(ActivityBase):
                     success=False, error="Failed to initialize chat skill"
                 )
 
-            # 2) Load personality + objectives from character config
+            # 2) Load system_prompt + twitter memory from acitivyt config, and personality + objectives from character config
+            self._sync_activity_config()
             character_config = self._get_character_config(shared_data)
             personality_data = character_config.get("personality", {})
             objectives_data = character_config.get("objectives", {})
@@ -158,7 +159,7 @@ class PostRecentMemoriesTweetActivity(ActivityBase):
             memory_obj = being.memory
 
         # Search in the last ~10 runs for this activity
-        recent_activities = memory_obj.get_recent_activities(limit=10, offset=0)
+        recent_activities = memory_obj.get_recent_activities(limit=self.num_activities_to_fetch, offset=0)
         for act in recent_activities:
             if act.get(
                 "activity_type"
@@ -167,6 +168,29 @@ class PostRecentMemoriesTweetActivity(ActivityBase):
                 if used:
                     return used
         return []
+
+    def _sync_activity_config(self):
+        """
+        synchronize activity config
+        """
+        # Load the config from the being
+        from framework.main import DigitalBeing
+        being = DigitalBeing()
+        being.initialize()
+        system_prompt = (
+            f"Please craft a short tweet (under {self.max_length} chars) that references these memories, "
+            f"reflects the personality and objectives, and ensures it's not repetitive or dull. "
+            f"Keep it interesting, cohesive, and mindful of the overall tone.\n"
+        )
+        num_activities_to_fetch = 10
+        if "activity_constraints" in being.configs and \
+            "activities_config" in being.configs["activity_constraints"] and \
+            "PostRecentMemoriesTweetActivity" in being.configs["activity_constraints"]["activities_config"]:
+            activities_config = being.configs["activity_constraints"]["activities_config"]["PostRecentMemoriesTweetActivity"]
+            system_prompt = activities_config.get("system_prompt", system_prompt)
+            num_activities_to_fetch = activities_config.get("num_activities_to_fetch", num_activities_to_fetch)
+        self.system_prompt = system_prompt
+        self.num_activities_to_fetch = num_activities_to_fetch
 
     def _get_character_config(self, shared_data) -> Dict[str, Any]:
         """
@@ -253,9 +277,7 @@ class PostRecentMemoriesTweetActivity(ActivityBase):
             f"{objectives_str}\n\n"
             f"Here are some new memories:\n"
             f"{memories_str}\n\n"
-            f"Please craft a short tweet (under 280 chars) that references these memories, "
-            f"reflects the personality and objectives, and ensures it's not repetitive or dull. "
-            f"Keep it interesting, cohesive, and mindful of the overall tone.\n"
+            f"{self.system_prompt}\n"
         )
         return prompt
 

--- a/my_digital_being/config_sample/activity_constraints.json
+++ b/my_digital_being/config_sample/activity_constraints.json
@@ -66,9 +66,13 @@
       "enabled": false
     },
     "PostTweetActivity": {
+      "system_prompt": "Write a new short tweet (under 280 chars), consistent with the above, but not repeating old tweets. Avoid hashtags or repeated phrases.",
+      "num_activities_to_fetch": 10,
       "enabled": false
     },
     "PostRecentMemoriesTweetActivity": {
+      "system_prompt": "Please craft a short tweet (under 280 chars) that references these memories, reflects the personality and objectives, and ensures it's not repetitive or dull. Keep it interesting, cohesive, and mindful of the overall tone.",
+      "num_activities_to_fetch": 10,
       "enabled": false
     },
     "AnalyzeNewCommitsActivity": {

--- a/my_digital_being/config_sample/skills_config.json
+++ b/my_digital_being/config_sample/skills_config.json
@@ -28,5 +28,14 @@
     "model_name": "openai/gpt-4o-mini",
     "required_api_keys": [],
     "api_key_mapping": {}
+  },
+  "twitter_posting": {
+    "enabled": true,
+    "required_api_keys": [
+      "TWITTER"
+    ],
+    "api_key_mapping": {
+      "TWITTER": "TWITTER_API_KEY"
+    }
   }
 }

--- a/my_digital_being/static/onboarding.js
+++ b/my_digital_being/static/onboarding.js
@@ -10,6 +10,7 @@
 
   // We'll store the loaded activity list globally so we can build checkboxes.
   let discoveredActivities = {};
+  let loadedConfigs;
 
   document.addEventListener('DOMContentLoaded', () => {
     // Insert a button in the overview tab for the wizard
@@ -141,6 +142,7 @@
       const charCfg = cfg.character_config || {};
       const skillCfg = cfg.skills_config || {};
       const constraintsCfg = cfg.activity_constraints || {};
+      loadedConfigs = cfg
 
       // Fill in the fields
       populateCharacterFields(charCfg);
@@ -308,7 +310,8 @@
         const checkboxId = `activity_checkbox_${moduleName}`;
         const boxEl = document.getElementById(checkboxId);
         const isChecked = boxEl ? boxEl.checked : true;
-        activities_config[className] = { "enabled": isChecked };
+        activities_config[className] = loadedConfigs.activity_constraints.activities_config[className]
+        activities_config[className].enabled = isChecked
       });
     }
 


### PR DESCRIPTION
## **Description**

Was looking into why Twitter posts all sound the same, and the causes were:

1. Using 10 recent tweets (hardcoded): For example, if set to 1, should only reference 1 recent tweet.
2. Using hardcoded system prompts: For example instead of `Please craft a short tweet (under 280 chars) that references these memories, reflects the personality and objectives, and ensures it's not repetitive or dull. Keep it interesting, cohesive, and mindful of the overall tone.', can do `Please craft a short tweet (under 140 chars) that references these memories, reflects the personality and objectives, and ensures it's not repetitive or dull. Keep it interesting, cohesive, and mindful of the overall tone. No emojis. Do NOT ask questions, just make statements.`

Instead of hardcoding, I looked into customizing these attributes via the config, at the moment it looks like the activity_constraints.json is the best place for it, but let me know if there are better places to configure this.

## **Type of Change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [O] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## **How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

1. Change the `system_prompt` or `num_activities_to_fetch` attribute from https://github.com/peanutcocktail/pippin/blob/main/my_digital_being/config_sample/activity_constraints.json#L68-L72 or https://github.com/peanutcocktail/pippin/blob/main/my_digital_being/config_sample/activity_constraints.json#L73-L77
2. Restart pippin.
3. It should now use that template instead of the previously hardcoded template.


## **Checklist:**

- [O] My code follows the style guidelines of this project
- [O] I have performed a self-review of my own code
- [O] I have commented my code, particularly in hard-to-understand areas
- [O] I have made corresponding changes to the documentation
- [O] My changes generate no new warnings
- [O] Any dependent changes have been merged and published in downstream modules

