### PR TITLE
Apply INFO level for server

### DIFF
--- a/my_digital_being/server.py
+++ b/my_digital_being/server.py
@@ -21,12 +21,15 @@ import websockets
 from websockets.server import serve
 from websockets.legacy.server import WebSocketServerProtocol
 
+# Initialize the logger with logging.INFO before importing other modules
+# to make sure INFO level logs are printed (Otherwise it gets set to WARN)
+logging.basicConfig(level=logging.INFO)
+
 # Import api_manager at top-level (not again inside any function)
 from framework.api_management import api_manager
 from framework.main import DigitalBeing
 from framework.skill_config import DynamicComposioSkills
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## **Description**

Currently, no INFO level logs are printed when running the server module.

This is because the `logging.basicConfig(level=logging.INFO)` gets ignored because it's called too late in the code. By moving it before importing other modules, we can ensure that the log level is set to INFO.


## **Type of Change**

Please delete options that are not relevant.

- [O] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## **How Has This Been Tested?**

Yes. Just try without this change and you'll see that none of the logger.info() logs are printed.

But with this change, all the info level logs are printed.

## **Checklist:**

- [O] My code follows the style guidelines of this project
- [O] I have performed a self-review of my own code
- [O] I have commented my code, particularly in hard-to-understand areas
- [O] I have made corresponding changes to the documentation
- [O] My changes generate no new warnings
- [O] Any dependent changes have been merged and published in downstream modules

## **Screenshots (if applicable):**

<img width="1106" alt="infolog" src="https://github.com/user-attachments/assets/8f8d4923-0018-43f6-80c1-9f70972e9f84" />
